### PR TITLE
fix: hide link edit buttons for non-owners, make posts public

### DIFF
--- a/.cursor/rules/convex_rules.mdc
+++ b/.cursor/rules/convex_rules.mdc
@@ -159,7 +159,7 @@ export const listWithExtraArg = query({
     handler: async (ctx, args) => {
         return await ctx.db
         .query("messages")
-        .filter((q) => q.eq(q.field("author"), args.author))
+        .withIndex("by_author", (q) => q.eq("author", args.author))
         .order("desc")
         .paginate(args.paginationOpts);
     },
@@ -198,7 +198,7 @@ export const exampleQuery = query({
     handler: async (ctx, args) => {
         const idToUsername: Record<Id<"users">, string> = {};
         for (const userId of args.userIds) {
-            const user = await ctx.db.get(userId);
+            const user = await ctx.db.get("users", userId);
             if (user) {
                 idToUsername[user._id] = user.username;
             }
@@ -236,8 +236,8 @@ const messages = await ctx.db
 
 
 ## Mutation guidelines
-- Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist.
-- Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist.
+- Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`
+- Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`
 
 ## Action guidelines
 - Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
@@ -307,7 +307,7 @@ export const exampleQuery = query({
     args: { fileId: v.id("_storage") },
     returns: v.null(),
     handler: async (ctx, args) => {
-        const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
+        const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
         console.log(metadata);
         return null;
     },
@@ -434,7 +434,7 @@ Internal Functions:
   "description": "This example shows how to build a chat app without authentication.",
   "version": "1.0.0",
   "dependencies": {
-    "convex": "^1.17.4",
+    "convex": "^1.31.2",
     "openai": "^4.79.0"
   },
   "devDependencies": {
@@ -480,8 +480,8 @@ import OpenAI from "openai";
 import { internal } from "./_generated/api";
 
 /**
-  * Create a user with a given name.
-  */
+ * Create a user with a given name.
+ */
 export const createUser = mutation({
   args: {
     name: v.string(),
@@ -493,8 +493,8 @@ export const createUser = mutation({
 });
 
 /**
-  * Create a channel with a given name.
-  */
+ * Create a channel with a given name.
+ */
 export const createChannel = mutation({
   args: {
     name: v.string(),
@@ -506,8 +506,8 @@ export const createChannel = mutation({
 });
 
 /**
-  * List the 10 most recent messages from a channel in descending creation order.
-  */
+ * List the 10 most recent messages from a channel in descending creation order.
+ */
 export const listMessages = query({
   args: {
     channelId: v.id("channels"),
@@ -532,8 +532,8 @@ export const listMessages = query({
 });
 
 /**
-  * Send a message to a channel and schedule a response from the AI.
-  */
+ * Send a message to a channel and schedule a response from the AI.
+ */
 export const sendMessage = mutation({
   args: {
     channelId: v.id("channels"),
@@ -667,9 +667,39 @@ export default defineSchema({
 });
 ```
 
+#### convex/tsconfig.json
+```typescript
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}
+```
+
 #### src/App.tsx
 ```typescript
 export default function App() {
   return <div>Hello World</div>;
 }
 ```
+

--- a/app/[handle]/page.tsx
+++ b/app/[handle]/page.tsx
@@ -246,12 +246,14 @@ export default function ProfilePage() {
                     <LinkItem
                       key={link._id}
                       link={link}
+                      isOwner={!!isOwner}
                       onEdit={() => setEditingLink(link._id)}
                     />
                   ))}
                 </div>
               )}
 
+              {/* Posts Section - Visible to everyone, but only ProMax owners can create */}
               {isOwner && (
                 <FeatureGate
                   title="Rich Media Posts"
@@ -259,19 +261,21 @@ export default function ProfilePage() {
                   requiredPlan="promax"
                   icon={PiShootingStarLight}
                 >
-                  <div className="space-y-6">
-                    <AddPostForm />
-                    <PostsList user={profileUser} />
-                  </div>
+                  <AddPostForm />
                 </FeatureGate>
               )}
 
-              {/* Public Posts & Booking Widget - Only show to visitors */}
+              {/* Posts list - visible to everyone */}
+              {userByHandle && (
+                <PostsList
+                  user={profileUser}
+                  currentUserId={currentUser?.id}
+                />
+              )}
+
+              {/* Booking Widget - Only show to visitors when owner has Pro */}
               {!isOwner && userByHandle && (
                 <>
-                  {userByHandle.subscriptionPlan === "promax" && (
-                    <PublicPostsWidget userId={userByHandle.userId} />
-                  )}
                   {userByHandle.subscriptionPlan === "pro" && (
                     <PublicBookingWidget userId={userByHandle.userId} />
                   )}

--- a/components/forms/user/link-item.tsx
+++ b/components/forms/user/link-item.tsx
@@ -15,10 +15,11 @@ interface LinkItemProps {
     href: string;
     icon?: string;
   };
+  isOwner?: boolean;
   onEdit?: () => void;
 }
 
-export function LinkItem({ link, onEdit }: LinkItemProps) {
+export function LinkItem({ link, isOwner = false, onEdit }: LinkItemProps) {
   const deleteLink = useMutation(api.links.deleteLink);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -52,30 +53,32 @@ export function LinkItem({ link, onEdit }: LinkItemProps) {
         {link.icon && <div className="text-2xl shrink-0">{link.icon}</div>}
         <span className="text-lg font-medium truncate">{link.anchor}</span>
       </Link>
-      <div className="flex items-center gap-2 shrink-0">
-        <Button
-          variant="ghost"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onEdit?.();
-          }}
-          className="p-2 hover:bg-primary-hover/50 rounded transition-colors text-primary-foreground"
-          disabled={isDeleting}
-          aria-label="Edit link"
-        >
-          <Pencil className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={handleDelete}
-          className="p-2 hover:bg-primary-hover/50 rounded transition-colors text-primary-foreground"
-          disabled={isDeleting}
-          aria-label="Delete link"
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </div>
+      {isOwner && (
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="ghost"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onEdit?.();
+            }}
+            className="p-2 hover:bg-primary-hover/50 rounded transition-colors text-primary-foreground"
+            disabled={isDeleting}
+            aria-label="Edit link"
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={handleDelete}
+            className="p-2 hover:bg-primary-hover/50 rounded transition-colors text-primary-foreground"
+            disabled={isDeleting}
+            aria-label="Delete link"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,14 +32,6 @@ import type {
   FunctionReference,
 } from "convex/server";
 
-/**
- * A utility for referencing Convex functions in your app's API.
- *
- * Usage:
- * ```js
- * const myFunctionReference = api.myModule.myFunction;
- * ```
- */
 declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   booking: typeof booking;
@@ -59,14 +51,30 @@ declare const fullApi: ApiFromModules<{
   users: typeof users;
   verifications: typeof verifications;
 }>;
-declare const fullApiWithMounts: typeof fullApi;
 
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
 export declare const api: FilterApi<
-  typeof fullApiWithMounts,
+  typeof fullApi,
   FunctionReference<any, "public">
 >;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
 export declare const internal: FilterApi<
-  typeof fullApiWithMounts,
+  typeof fullApi,
   FunctionReference<any, "internal">
 >;
 

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -10,7 +10,6 @@
 
 import {
   ActionBuilder,
-  AnyComponents,
   HttpActionBuilder,
   MutationBuilder,
   QueryBuilder,
@@ -19,14 +18,8 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
-  FunctionReference,
 } from "convex/server";
 import type { DataModel } from "./dataModel.js";
-
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
 
 /**
  * Define a query in this Convex app's public API.
@@ -92,11 +85,12 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
 /**
  * Define an HTTP action.
  *
- * This function will be used to respond to HTTP requests received by a Convex
- * deployment if the requests matches the path and method where this action
- * is routed. Be sure to route your action in `convex/http.js`.
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -16,7 +16,6 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
-  componentsGeneric,
 } from "convex/server";
 
 /**
@@ -81,10 +80,14 @@ export const action = actionGeneric;
 export const internalAction = internalActionGeneric;
 
 /**
- * Define a Convex HTTP action.
+ * Define an HTTP action.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument, and a `Request` object
- * as its second.
- * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
- Add isOwner prop to LinkItem component
- Only show edit/delete buttons when isOwner is true
- Pass isOwner to LinkItem in profile page
- Move posts list outside FeatureGate (visible to everyone)
- Keep AddPostForm gated behind promax for owners
- Update PostCard with like/reply/repost counts
- Add like button functionality for signed-in users