### PR TITLE
fix: reposts show original content, replies visible in thread

### DIFF
--- a/components/profile/public/handle.tsx
+++ b/components/profile/public/handle.tsx
@@ -8,17 +8,26 @@ import Plan from "./badges/plan";
 export default function Handle({
   user,
   withAvatar = true,
+  inline = false,
   className = "flex items-center gap-2 justify-start p-2",
   children,
   ...props
 }: {
   user: User;
   withAvatar?: boolean;
+  inline?: boolean;
   className?: string;
   children?: React.ReactNode;
 }) {
   if (!user) {
     return null;
+  }
+
+  // Inline mode - just the handle text for embedding in sentences
+  if (inline) {
+    return (
+      <span className="font-semibold">@{user.handle}</span>
+    );
   }
 
   return (


### PR DESCRIPTION
## Fixes

**Bug 1: Reposts showing no content**
- Reposts now properly display the original post's content
- Added repost attribution header showing who reposted
- Quote reposts show quote text above original content

**Bug 2: Thread not visible after replying**
- Added expandable thread view for replies
- Click 'Show X replies' to expand the thread
- Auto-expands replies after you post a new reply
- Thread depth limited to 3 levels for readability

## Changes
- `components/views/posts/card.tsx` - Added repost display logic and thread expansion
- `components/profile/public/handle.tsx` - Added inline mode for repost attribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline rendering mode for user handles enabling simplified display
  * Introduced threaded reply system with expand/collapse functionality to view reply conversations
  * Added repost origin display showing when content is reposted with optional quoted content
  * Implemented on-demand reply loading for improved performance and real-time updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->